### PR TITLE
Fix spatial join temporal key naming

### DIFF
--- a/src/main/scala/astraea/spark/rasterframes/RasterFrameMethods.scala
+++ b/src/main/scala/astraea/spark/rasterframes/RasterFrameMethods.scala
@@ -164,7 +164,7 @@ trait RasterFrameMethods extends MethodExtensions[RasterFrame] with RFSpatialCol
 
       left.temporalKeyColumn.tupleWith(leftTemporalKey).combine(spatialFix) {
         case ((orig, updated), rf) ⇒ rf
-          .withColumnRenamed(orig.columnName, updated.columnName)
+          .withColumnRenamed(updated.columnName, orig.columnName)
           .drop(rightTemporalKey.get.columnName)
       }
     } else joined


### PR DESCRIPTION
On inner join, if there's a temporal key, have it named the same as the left side's original.  
