### PR TITLE
Fix inverted local agg nodata count

### DIFF
--- a/src/main/scala/astraea/spark/rasterframes/ColumnFunctions.scala
+++ b/src/main/scala/astraea/spark/rasterframes/ColumnFunctions.scala
@@ -216,7 +216,7 @@ trait ColumnFunctions {
   @Experimental
   def localAggNoDataCells(col: Column): TypedColumn[Any, Tile] =
   withAlias("localCount", col)(
-    F.localAggCount(col)
+    F.localAggNodataCount(col)
   ).as[Tile]
 
   /** Cellwise addition between two Tiles. */

--- a/src/main/scala/astraea/spark/rasterframes/functions/package.scala
+++ b/src/main/scala/astraea/spark/rasterframes/functions/package.scala
@@ -198,6 +198,9 @@ package object functions {
   /** Compute the cell-wise count of non-NA across tiles. */
   private[rasterframes] val localAggCount = new LocalCountAggregateFunction(true)
 
+  /** Compute the cell-wise count of non-NA across tiles. */
+  private[rasterframes] val localAggNodataCount = new LocalCountAggregateFunction(false)
+
   /** Cell-wise addition between tiles. */
   private[rasterframes] val localAdd: (Tile, Tile) ⇒ Tile = safeEval(Add.apply)
 

--- a/src/test/scala/astraea/spark/rasterframes/TileStatsSpec.scala
+++ b/src/test/scala/astraea/spark/rasterframes/TileStatsSpec.scala
@@ -197,7 +197,7 @@ class TileStatsSpec extends TestEnvironment with TestData  {
 
     it("should compute accurate statistics") {
       val completeTile = squareIncrementingTile(4).convert(IntConstantNoDataCellType)
-      val incompleteTile = injectND(2)(completeTile)
+      val incompleteTile = injectND(2)(completeTile).convert(IntConstantNoDataCellType)
 
       val ds = (Seq.fill(20)(completeTile) :+ null).toDF("tiles")
       val dsNd = (Seq.fill(20)(completeTile) ++ Seq(incompleteTile)).toDF("tiles")

--- a/src/test/scala/astraea/spark/rasterframes/TileStatsSpec.scala
+++ b/src/test/scala/astraea/spark/rasterframes/TileStatsSpec.scala
@@ -196,22 +196,34 @@ class TileStatsSpec extends TestEnvironment with TestData  {
     }
 
     it("should compute accurate statistics") {
-      val tile = squareIncrementingTile(4).convert(IntConstantNoDataCellType)
+      val completeTile = squareIncrementingTile(4).convert(IntConstantNoDataCellType)
+      val incompleteTile = injectND(2)(completeTile)
 
-      val ds = (Seq.fill(20)(tile) :+ null).toDF("tiles")
+      val ds = (Seq.fill(20)(completeTile) :+ null).toDF("tiles")
+      val dsNd = (Seq.fill(20)(completeTile) ++ Seq(incompleteTile)).toDF("tiles")
 
       // counted everything properly
       val countTile = ds.select(localAggDataCells($"tiles")).first()
       forAll(countTile.toArray())(i ⇒ assert(i === 20))
 
-      val meanTile = ds.select(localAggMean($"tiles")).first()
-      assert(meanTile.toArray() === tile.toArray())
+      val countArray = dsNd.select(localAggDataCells($"tiles")).first().toArray()
+      val expectedCount = (completeTile.localDefined().toArray zip incompleteTile.localDefined().toArray())
+          .toSeq.map(pr ⇒ pr._1 * 20 + pr._2)
+      assert(countArray === expectedCount)
 
-      val minTile = ds.select(localAggMin($"tiles")).first()
-      assert(minTile.toArray() === tile.toArray())
+      val countNodataArray = dsNd.select((localAggNoDataCells($"tiles"))).first().toArray
+//      val expectedNDCount = (completeTile.localUndefined().toArray zip incompleteTile.localUndefined().toArray())
+//        .toSeq.map(pr ⇒ pr._1 * 20 + pr._2)
+      assert( countNodataArray === incompleteTile.localUndefined().toArray)
 
-      val maxTile = ds.select(localAggMax($"tiles")).first()
-      assert(maxTile.toArray() === tile.toArray())
+      val meanTile = dsNd.select(localAggMean($"tiles")).first()
+      assert(meanTile.toArray() === completeTile.toArray())
+
+      val minTile = dsNd.select(localAggMin($"tiles")).first()
+      assert(minTile.toArray() === completeTile.toArray())
+
+      val maxTile = dsNd.select(localAggMax($"tiles")).first()
+      assert(maxTile.toArray() === completeTile.toArray())
     }
 
     it("should count cells by no-data state") {


### PR DESCRIPTION
Note that now TileStatsSpec fails because min treats the NODATA value as a value. Need to fix.